### PR TITLE
ros2-add-tagを修正

### DIFF
--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     permissions:
-      packages: write
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Add tag
         uses: ./.traps-github-action/ros2-add-tag
+        with:
+          path: .traps-github-action
+

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -1,0 +1,17 @@
+name: Add tag
+
+run-name: Colcon Test test:${{ github.ref_name }}(${{ github.event.head_commit.message }})
+
+on:
+  push:
+
+jobs:
+  add-tag:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Add tag
+        uses: ./.traps-github-action/ros2-add-tag

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -4,8 +4,8 @@ run-name: Add tag:${{ github.ref_name }}(${{ github.event.head_commit.message }}
 
 on:
   push:
-    # branches:
-      # - 'main'
+    branches:
+      - 'main'
 
 jobs:
   add-tag:

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -5,7 +5,7 @@ run-name: Add tag:${{ github.ref_name }}(${{ github.event.head_commit.message }}
 on:
   push:
     branches:
-      - 'main'
+      # - 'main'
 
 jobs:
   add-tag:

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -4,7 +4,7 @@ run-name: Add tag:${{ github.ref_name }}(${{ github.event.head_commit.message }}
 
 on:
   push:
-    branches:
+    # branches:
       # - 'main'
 
 jobs:
@@ -15,5 +15,10 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: .traps-github-action
+
       - name: Add tag
         uses: ./.traps-github-action/ros2-add-tag

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -4,6 +4,8 @@ run-name: Colcon Test test:${{ github.ref_name }}(${{ github.event.head_commit.m
 
 on:
   push:
+    branches:
+      - 'main'
 
 jobs:
   add-tag:

--- a/.github/workflows/ros2-add-tag-test.yaml
+++ b/.github/workflows/ros2-add-tag-test.yaml
@@ -1,6 +1,6 @@
 name: Add tag
 
-run-name: Colcon Test test:${{ github.ref_name }}(${{ github.event.head_commit.message }})
+run-name: Add tag:${{ github.ref_name }}(${{ github.event.head_commit.message }})
 
 on:
   push:

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -45,8 +45,8 @@ runs:
     - name: Push the tag if it does not exist
       working-directory: ${{ inputs.path }}
       run: |
-        git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
-        git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
+        git config --global user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
+        git config --global user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -45,8 +45,8 @@ runs:
     - name: Push the tag if it does not exist
       working-directory: ${{ inputs.path }}
       run: |
-        git config --global user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
-        git config --global user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
+        git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
+        git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -47,7 +47,7 @@ runs:
       run: |
         git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
         git config --local user.name $(xmllint --xpath 'string(/package/maintainer)' package.xml)
-        PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
+        PACKAGE_VERSION=$(xmllint --xpath "string(/package/version)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then
           git tag -a ${PACKAGE_VERSION} -m "$(git log -1 --pretty=%B)"

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -43,8 +43,9 @@ runs:
       shell: bash
 
     - name: Push the tag if it does not exist
+      working-directory: ${{ inputs.path }}
       run: |
-        PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" ".package.xml")
+        PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then
           git tag -a ${PACKAGE_VERSION} -m $(git log -1 --pretty=%B)

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -46,6 +46,6 @@ runs:
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" ".package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then
-          git tag ${PACKAGE_VERSION}
+          git tag -a ${PACKAGE_VERSION} -m $(git log -1 --pretty=%B)
           git push origin ${PACKAGE_VERSION}
         fi

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -40,6 +40,7 @@ runs:
 
     - name: Install xmmlint
       run: sudo apt update && sudo apt install -y libxml2-utils
+      shell: bash
 
     - name: Push the tag if it does not exist
       run: |
@@ -49,3 +50,4 @@ runs:
           git tag -a ${PACKAGE_VERSION} -m $(git log -1 --pretty=%B)
           git push origin ${PACKAGE_VERSION}
         fi
+      shell: bash

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -42,6 +42,16 @@ runs:
       run: sudo apt update && sudo apt install -y libxml2-utils
       shell: bash
 
+    - name: Set git user email
+      working-directory: ${{ inputs.path }}
+      run: git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
+      shell: bash
+
+    - name: Set git user name
+      working-directory: ${{ inputs.path }}
+      run: git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
+      shell: bash
+
     - name: Push the tag if it does not exist
       working-directory: ${{ inputs.path }}
       run: |

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -46,7 +46,7 @@ runs:
       working-directory: ${{ inputs.path }}
       run: |
         git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
-        git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
+        git config --local user.name $(xmllint --xpath 'string(/package/maintainer)' package.xml)
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -42,19 +42,11 @@ runs:
       run: sudo apt update && sudo apt install -y libxml2-utils
       shell: bash
 
-    - name: Set git user email
-      working-directory: ${{ inputs.path }}
-      run: git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
-      shell: bash
-
-    - name: Set git user name
-      working-directory: ${{ inputs.path }}
-      run: git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
-      shell: bash
-
     - name: Push the tag if it does not exist
       working-directory: ${{ inputs.path }}
       run: |
+        git config --local user.email $(xmllint --xpath 'string(/package/maintainer/@email)' package.xml)
+        git config --local user.email $(xmllint --xpath 'string(/package/maintainer)' package.xml)
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then

--- a/ros2-add-tag/action.yaml
+++ b/ros2-add-tag/action.yaml
@@ -50,7 +50,7 @@ runs:
         PACKAGE_VERSION=$(xmllint --xpath "string(/package/name)" "package.xml")
         if ! git tag | grep ${PACKAGE_VERSION} > /dev/null
         then
-          git tag -a ${PACKAGE_VERSION} -m $(git log -1 --pretty=%B)
+          git tag -a ${PACKAGE_VERSION} -m "$(git log -1 --pretty=%B)"
           git push origin ${PACKAGE_VERSION}
         fi
       shell: bash


### PR DESCRIPTION
- git tagのメッセージの説明に、タグ追加時のcommitのメッセージを設定
- 不足していたshell指定を追加
- test workflowを追加
- ダブルクォーテーションのつけ忘れを修正
- パッケージのバージョンじゃなくて名前をtag付していたのを修正
- ダブルクォーテーションのつけ忘れを修正
- 必要だったgit configを設定