### PR TITLE
fix: recursively find package.xml in .pkg_meta preparation

### DIFF
--- a/docker-build-pkg/action.yaml
+++ b/docker-build-pkg/action.yaml
@@ -138,11 +138,11 @@ runs:
   - name: Prepare package metadata for dependency cache
     run: |
       mkdir -p .pkg_meta
-      for d in src/*/; do
-        [ -f "${d}package.xml" ] || continue
-        pkg="$(basename "$d")"
-        mkdir -p ".pkg_meta/${pkg}"
-        cp "${d}package.xml" ".pkg_meta/${pkg}/package.xml"
+      find src -name package.xml -type f | while read -r pxml; do
+        rel="${pxml#src/}"
+        dir="$(dirname "$rel")"
+        mkdir -p ".pkg_meta/${dir}"
+        cp "$pxml" ".pkg_meta/${dir}/package.xml"
       done
     shell: bash
 


### PR DESCRIPTION
## Summary

- Fix `.pkg_meta/` preparation to find `package.xml` at any depth, not just `src/*/`
- Multi-package repos (e.g., `traps_phoenix_ros_v2/{phoenix_hal,phoenix_protocol,phoenix_driver}`) were missed because their `package.xml` files are at depth 2
- This caused `rosdep install` to skip dependencies like `libexpected-dev` and `libgpiod-dev`, failing the Docker build with `fatal error: tl/expected.hpp: No such file or directory`

## Changes

Replace `for d in src/*/` (depth-1 only) with `find src -name package.xml -type f` (recursive), preserving the full relative directory structure in `.pkg_meta/`.

Before (broken for multi-package repos):
```
.pkg_meta/
  traps_ai_bridge_ros/package.xml     ← only single-package repos found
```

After (all packages found):
```
.pkg_meta/
  traps_phoenix_ros_v2/phoenix_hal/package.xml
  traps_phoenix_ros_v2/phoenix_protocol/package.xml
  traps_phoenix_ros_v2/phoenix_driver/package.xml
  traps_ai_bridge_ros/package.xml
```

## Test plan

- [ ] Docker Build CI on `traps_phoenix_ros_v2` passes after merging
- [ ] `rosdep install` output includes `libexpected-dev` and `libgpiod-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)